### PR TITLE
FIX: CEI reorder in closeSale/burnLp + scoped approval in burnLp

### DIFF
--- a/contracts/modules/CrowdfundingModule.sol
+++ b/contracts/modules/CrowdfundingModule.sol
@@ -320,10 +320,10 @@ contract CrowdfundingModule is
             .tokenAddress;
         uint256 tokenAmount = filledTokenAmount[msg.sender][currentIndex];
 
-        IERC20Upgradeable(tokenAddress).safeTransfer(msg.sender, tokenAmount);
-
         ++saleIndexes[msg.sender];
         filledTokenAmount[msg.sender][currentIndex] = 0;
+
+        IERC20Upgradeable(tokenAddress).safeTransfer(msg.sender, tokenAmount);
 
         emit CloseSale(msg.sender, currentIndex);
     }
@@ -340,15 +340,13 @@ contract CrowdfundingModule is
             "CrowdfundingModule: not enough balance"
         );
 
+        filledTokenAmount[_dao][currentIndex] -= lpAmount;
+
         IERC20Upgradeable lp = IERC20Upgradeable(IDao(_dao).lp());
 
-        require(
-            lp.approve(address(privateExitModule), lp.balanceOf(address(this)))
-        );
+        require(lp.approve(address(privateExitModule), lpAmount));
 
         require(privateExitModule.privateExit(_dao, _id));
-
-        filledTokenAmount[_dao][currentIndex] -= lpAmount;
     }
 
     function buy(


### PR DESCRIPTION
Follow-up to commit 3ac2eec (cross-tenant token confusion guard).

**closeSale():** moved `++saleIndexes` and `filledTokenAmount = 0` before the external `safeTransfer` call — prevents potential reentrancy via ERC-777 token callbacks draining the shared custody pool.

**burnLp():** moved `filledTokenAmount -= lpAmount` before external `approve`/`privateExit` calls — same CEI fix. Replaced `lp.approve(privateExitModule, lp.balanceOf(address(this)))` with `lp.approve(privateExitModule, lpAmount)` — approve only the exact amount needed instead of the entire module LP balance across all DAOs.

No storage layout changes, no ABI changes, no new code — only reordered existing lines and scoped one approval.